### PR TITLE
fix: spotifyアルバムジャケットの画像最適化を廃止

### DIFF
--- a/drivers/views/components/layout/DefaultFooter.tsx
+++ b/drivers/views/components/layout/DefaultFooter.tsx
@@ -3,7 +3,7 @@ const DefaultFooter = () => {
     <footer className="flex flex-col justify-center gap-y-3 p-8 text-center">
       <div>(c) 2022 temasaguru</div>
       <div className="text-sm">
-        {`当サイトに掲載しているアルバムアートワークは著作権法上の範囲でSpotifyから引用しており、楽曲の権利は提供元に帰属します。`}
+        {`当サイトに掲載しているアルバムアートワークはSpotify APIで取得したURLを使って表示しており、公式やDiscordの埋め込み機能と同様にSpotifyサーバーの画像をそのまま埋め込んでいるため、権利上の問題はないと判断し運用しています。楽曲の権利は提供元に帰属します。`}
         <br className="hidden xl:block" />
         {`当サイトはいかなる広告・解析サービスも使用しておらず、管理画面以外でCookieは使用しておりません。`}
       </div>

--- a/drivers/views/components/spotify/AlbumArt.tsx
+++ b/drivers/views/components/spotify/AlbumArt.tsx
@@ -1,8 +1,8 @@
-import Image, { ImageProps } from 'next/image';
 import { SpotifyTrackJSON } from '@/application/interfaces/json/spotify/common';
+import { ComponentPropsWithoutRef } from 'react';
 
 interface AlbumArtProps {
-  loading?: ImageProps['loading'];
+  loading?: ComponentPropsWithoutRef<'img'>['loading'];
   track: SpotifyTrackJSON | null;
   hasError: boolean;
 }
@@ -18,28 +18,16 @@ const AlbumArt = ({ loading = 'lazy', track, hasError }: AlbumArtProps) => {
         <>
           {albumImage ? (
             <>
-              {albumImage.url.startsWith('https://i.scdn.co') ? (
-                <Image
-                  width={300}
-                  height={300}
-                  src={albumImage?.url}
-                  alt={track?.album.name ?? ''}
-                  loading={loading}
-                  // 遅延読み込みでない場合はpriorityが必要 https://nextjs.org/docs/api-reference/next/image#priority
-                  priority={loading !== 'lazy'}
-                  className="w-full"
-                />
-              ) : (
-                <>
-                  {/* 多分i.scdn.coがSpotifyのCDNなんだろうが、突然変えられると対応できないのでimgで対処 */}
-                  {/* eslint-disable-next-line @next/next/no-img-element */}
-                  <img
-                    src={albumImage?.url}
-                    alt={track?.album.name ?? ''}
-                    className="w-full"
-                  />
-                </>
-              )}
+              {/* 公式やDiscordの埋め込みと同様、SpotifyのCDNから直接表示 再キャッシュはしない */}
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img
+                width={300}
+                height={300}
+                src={albumImage?.url}
+                alt={track?.album.name ?? ''}
+                loading={loading}
+                className="w-full"
+              />
             </>
           ) : (
             <div className="flex h-full items-center justify-center bg-blue-900 text-white">

--- a/next.config.js
+++ b/next.config.js
@@ -17,14 +17,6 @@ const nextConfig = {
      */
     NEXTAUTH_URL: process.env.NEXTAUTH_URL,
   },
-  images: {
-    domains: [
-      /**
-       * Spotify CDN
-       */
-      'i.scdn.co',
-    ],
-  },
 };
 
 module.exports = withBundleAnalyzer(nextConfig);


### PR DESCRIPTION
close #16