### PR TITLE
fix: spotifyポッドキャスト表示に対応 お気に入りEPsは未対応

### DIFF
--- a/application/interfaces/json/spotify/common.ts
+++ b/application/interfaces/json/spotify/common.ts
@@ -14,6 +14,7 @@ export interface SpotifyArtistJSON {
 
 /**
  * コンポーネントで使用する曲情報
+ * 設計簡略化のため、ポッドキャストもこの形式に変換する
  */
 export interface SpotifyTrackJSON {
   /** mapした際にkeyで使う */


### PR DESCRIPTION
Closes #18